### PR TITLE
Add ASP.NET Core 6.0 requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Currently, stock prices are retrieved using the free API [brapi](https://brapi.d
 1. Register an account on [brapi](https://brapi.dev) to generate your own API key, then put it on "./StockTrackerService/StockTrackerService.dll.config" file;
 
 1. Run "StockTracker.exe" for the first time to schedule the service task that will initialize service on user logon;
+
+## Requirements
+
+* ASP.NET Core 6.0 is required to run the application.
+* The project targets .NET 6.0, which includes ASP.NET Core 6.0.


### PR DESCRIPTION
Related to #4

Add ASP.NET Core 6.0 requirement to README.md

* Add a new section "Requirements" under "Application Instructions"
* Specify that ASP.NET Core 6.0 is required to run the application
* Mention that the project targets .NET 6.0, which includes ASP.NET Core 6.0

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/LamenLuan/StockTracker/pull/5?shareId=c4d5e0f6-9d85-4f9f-9386-b886b3a2f570).